### PR TITLE
Fix stdio

### DIFF
--- a/src/backend/ansi.zig
+++ b/src/backend/ansi.zig
@@ -31,8 +31,8 @@ pub const AnsiBackend = struct {
             return error.UnsupportedTerminal; // Use windows.zig backend instead
         }
 
-        const stdin = std.io.getStdIn();
-        const stdout = std.io.getStdOut();
+        const stdin = std.fs.File.stdin();
+        const stdout = std.fs.File.stdout();
 
         // Save original terminal settings
         const original = if (is_posix) try posix.tcgetattr(stdin.handle) else {};


### PR DESCRIPTION
In zig version 0.15.2+ are `std.io.getStdIn()` and `std.Io.getStdOut()` no longer available.

I updated this, to use the `std.fs.File` functions and the example build and seems to work.
