### PR TITLE
Setting terminal codepage to UTF8 on Windows

### DIFF
--- a/examples/dashboard.zig
+++ b/examples/dashboard.zig
@@ -13,6 +13,7 @@ const Style = tui.style.Style;
 const Modifier = tui.style.Modifier;
 const Block = tui.widgets.Block;
 const Borders = tui.widgets.Borders;
+const BorderSymbols = tui.widgets.BorderSymbols;
 
 const AppState = struct {
     running: bool = true,
@@ -47,14 +48,14 @@ const AppState = struct {
 
     fn update(self: *AppState) void {
         self.tick += 1;
-        
+
         // Simulate changing values
         const seed = @as(u32, @truncate(self.tick));
         self.cpu_usage = @intCast(30 + (seed * 7) % 40);
         self.mem_usage = @intCast(50 + (seed * 3) % 30);
         self.network_in = 800 + (seed * 13) % 1000;
         self.network_out = 200 + (seed * 11) % 600;
-        
+
         // Update history
         self.cpu_history[self.history_index] = self.cpu_usage;
         self.mem_history[self.history_index] = self.mem_usage;
@@ -129,6 +130,7 @@ pub fn main() !void {
                     .style = Style{ .bg = .black },
                     .border_style = Style{ .fg = .cyan },
                     .title_style = Style{ .fg = .white, .modifier = Modifier{ .bold = true } },
+                    .border_symbols = BorderSymbols.double(),
                 };
                 main_block.render(area, buf);
 
@@ -145,7 +147,7 @@ pub fn main() !void {
                 // Top row: System stats
                 const top_height = 7;
                 const top_area = Rect{ .x = inner.x, .y = inner.y, .width = inner.width, .height = top_height };
-                
+
                 // Bottom area: Process list and logs
                 const bottom_y = inner.y + top_height;
                 const bottom_height = inner.height -| top_height;
@@ -154,7 +156,7 @@ pub fn main() !void {
                 // Draw panels
                 drawSystemStats(top_area, buf, app);
                 drawBottomPanels(bottom_area, buf, app);
-                
+
                 // Draw footer
                 drawFooter(area, buf);
             }
@@ -166,21 +168,21 @@ pub fn main() !void {
 
 fn drawSystemStats(area: Rect, buf: *Buffer, state: *AppState) void {
     if (area.width < 20) return;
-    
+
     const panel_width = area.width / 4;
-    
+
     // CPU Panel
     const cpu_area = Rect{ .x = area.x, .y = area.y, .width = panel_width, .height = area.height };
     drawGaugePanel(cpu_area, buf, "CPU", state.cpu_usage, .cyan, state.selected_panel == 0);
-    
+
     // Memory Panel
     const mem_area = Rect{ .x = area.x + panel_width, .y = area.y, .width = panel_width, .height = area.height };
     drawGaugePanel(mem_area, buf, "Memory", state.mem_usage, .green, state.selected_panel == 1);
-    
+
     // Disk Panel
     const disk_area = Rect{ .x = area.x + panel_width * 2, .y = area.y, .width = panel_width, .height = area.height };
     drawGaugePanel(disk_area, buf, "Disk", state.disk_usage, .yellow, state.selected_panel == 2);
-    
+
     // Network Panel
     const net_area = Rect{ .x = area.x + panel_width * 3, .y = area.y, .width = area.width - panel_width * 3, .height = area.height };
     drawNetworkPanel(net_area, buf, state);
@@ -193,23 +195,24 @@ fn drawGaugePanel(area: Rect, buf: *Buffer, title: []const u8, value: u8, color:
         .borders = Borders.all(),
         .border_style = Style{ .fg = border_color, .modifier = if (selected) Modifier{ .bold = true } else .{} },
         .title_style = Style{ .fg = color, .modifier = Modifier{ .bold = true } },
+        .border_symbols = BorderSymbols.rounded(),
     };
     block.render(area, buf);
-    
+
     if (area.height < 4 or area.width < 6) return;
-    
+
     // Value display
     var val_buf: [8]u8 = undefined;
     const val_str = std.fmt.bufPrint(&val_buf, "{d}%", .{value}) catch return;
     const val_x = area.x + (area.width -| @as(u16, @intCast(val_str.len))) / 2;
     buf.setString(val_x, area.y + 2, val_str, Style{ .fg = color, .modifier = Modifier{ .bold = true } });
-    
+
     // Progress bar using ASCII characters for Windows compatibility
     if (area.height >= 5 and area.width >= 6) {
         const bar_width = area.width -| 4;
         const filled = @as(u16, @intCast(value)) * bar_width / 100;
         const bar_y = area.y + 4;
-        
+
         // Draw bar with ASCII: '#' for filled, '-' for empty
         var i: u16 = 0;
         while (i < bar_width) : (i += 1) {
@@ -226,16 +229,17 @@ fn drawNetworkPanel(area: Rect, buf: *Buffer, state: *AppState) void {
         .borders = Borders.all(),
         .border_style = Style{ .fg = .gray },
         .title_style = Style{ .fg = .magenta, .modifier = Modifier{ .bold = true } },
+        .border_symbols = BorderSymbols.rounded(),
     };
     block.render(area, buf);
-    
+
     if (area.height < 4 or area.width < 10) return;
-    
+
     // Download - using ASCII 'v' instead of Unicode arrow
     var dl_buf: [20]u8 = undefined;
     const dl_str = std.fmt.bufPrint(&dl_buf, "v {d} KB/s", .{state.network_in}) catch return;
     buf.setString(area.x + 2, area.y + 2, dl_str, Style{ .fg = .green });
-    
+
     // Upload - using ASCII '^' instead of Unicode arrow
     var ul_buf: [20]u8 = undefined;
     const ul_str = std.fmt.bufPrint(&ul_buf, "^ {d} KB/s", .{state.network_out}) catch return;
@@ -244,13 +248,13 @@ fn drawNetworkPanel(area: Rect, buf: *Buffer, state: *AppState) void {
 
 fn drawBottomPanels(area: Rect, buf: *Buffer, state: *AppState) void {
     if (area.width < 20) return;
-    
+
     const left_width = area.width / 2;
-    
+
     // Process list
     const proc_area = Rect{ .x = area.x, .y = area.y, .width = left_width, .height = area.height };
     drawProcessList(proc_area, buf, state);
-    
+
     // Sparkline / Activity
     const spark_area = Rect{ .x = area.x + left_width, .y = area.y, .width = area.width - left_width, .height = area.height };
     drawActivityPanel(spark_area, buf, state);
@@ -263,33 +267,34 @@ fn drawProcessList(area: Rect, buf: *Buffer, state: *AppState) void {
         .borders = Borders.all(),
         .border_style = Style{ .fg = if (selected) .white else .gray, .modifier = if (selected) Modifier{ .bold = true } else .{} },
         .title_style = Style{ .fg = .yellow, .modifier = Modifier{ .bold = true } },
+        .border_symbols = BorderSymbols.line(),
     };
     block.render(area, buf);
-    
+
     if (area.height < 4 or area.width < 20) return;
-    
+
     // Header
     buf.setString(area.x + 2, area.y + 1, "NAME", Style{ .fg = .cyan, .modifier = Modifier{ .bold = true } });
     buf.setString(area.x + 14, area.y + 1, "CPU", Style{ .fg = .cyan, .modifier = Modifier{ .bold = true } });
     buf.setString(area.x + 20, area.y + 1, "MEM", Style{ .fg = .cyan, .modifier = Modifier{ .bold = true } });
-    
-    // Separator - using ASCII dash for Windows compatibility
+
+    // Separator ─ using ASCII dash for Windows compatibility
     var i: u16 = 0;
     while (i < area.width -| 4) : (i += 1) {
-        buf.setChar(area.x + 2 + i, area.y + 2, '-', Style{ .fg = .dark_gray });
+        buf.setChar(area.x + 2 + i, area.y + 2, '─', Style{ .fg = .dark_gray });
     }
-    
+
     // Process rows
     const max_rows = @min(state.processes.len, area.height -| 4);
     for (state.processes[0..max_rows], 0..) |proc, idx| {
         const y = area.y + 3 + @as(u16, @intCast(idx));
         const is_selected = selected and idx == state.selected_process;
-        
+
         const row_style = if (is_selected)
             Style{ .fg = .black, .bg = .cyan }
         else
             Style{ .fg = .white };
-        
+
         // Fill row background if selected
         if (is_selected) {
             var x: u16 = 0;
@@ -297,13 +302,13 @@ fn drawProcessList(area: Rect, buf: *Buffer, state: *AppState) void {
                 buf.setChar(area.x + 2 + x, y, ' ', row_style);
             }
         }
-        
+
         buf.setString(area.x + 2, y, proc.name, row_style);
-        
+
         var cpu_buf: [8]u8 = undefined;
         const cpu_str = std.fmt.bufPrint(&cpu_buf, "{d}%", .{proc.cpu}) catch continue;
         buf.setString(area.x + 14, y, cpu_str, row_style);
-        
+
         var mem_buf: [12]u8 = undefined;
         const mem_str = std.fmt.bufPrint(&mem_buf, "{d}MB", .{proc.mem}) catch continue;
         buf.setString(area.x + 20, y, mem_str, row_style);
@@ -317,31 +322,32 @@ fn drawActivityPanel(area: Rect, buf: *Buffer, state: *AppState) void {
         .borders = Borders.all(),
         .border_style = Style{ .fg = if (selected) .white else .gray },
         .title_style = Style{ .fg = .cyan, .modifier = Modifier{ .bold = true } },
+        .border_symbols = BorderSymbols.line(),
     };
     block.render(area, buf);
-    
+
     if (area.height < 4 or area.width < 10) return;
-    
+
     // Draw sparkline using ASCII characters for Windows compatibility
     const spark_width = @min(@as(usize, area.width -| 4), 60);
     const spark_height = area.height -| 3;
-    
+
     if (spark_height == 0) return;
-    
+
     // ASCII bar visualization: '_', '.', '-', '=', '#', '@'
     const blocks = [_]u21{ ' ', '_', '.', '-', '=', '#', '@', '*', '|' };
-    
+
     var x: usize = 0;
     while (x < spark_width) : (x += 1) {
         const hist_idx = (state.history_index + 60 - spark_width + x) % 60;
         const value = state.cpu_history[hist_idx];
         const normalized = @as(usize, value) * 8 / 100;
         const char = blocks[@min(normalized, 8)];
-        
+
         const color: Color = if (value > 80) .red else if (value > 50) .yellow else .cyan;
         buf.setChar(area.x + 2 + @as(u16, @intCast(x)), area.y + area.height - 2, char, Style{ .fg = color });
     }
-    
+
     // Draw scale
     buf.setString(area.x + 2, area.y + 1, "100%", Style{ .fg = .dark_gray });
     buf.setString(area.x + 2, area.y + area.height - 3, "0%", Style{ .fg = .dark_gray });

--- a/src/widgets/mod.zig
+++ b/src/widgets/mod.zig
@@ -1,4 +1,3 @@
-
 //! Widgets module - Reusable UI components
 
 const std = @import("std");
@@ -52,6 +51,7 @@ pub const Block = struct {
     style: Style = .{},
     border_style: Style = .{},
     title_style: Style = .{},
+    border_symbols: BorderSymbols = BorderSymbols.default(),
 
     pub fn render(self: Block, area: Rect, buf: *Buffer) void {
         // Safety check: skip rendering if area is too small
@@ -85,7 +85,7 @@ pub const Block = struct {
     }
 
     fn renderBorders(self: Block, area: Rect, buf: *Buffer) void {
-        const symbols = BorderSymbols.default();
+        const symbols = self.border_symbols;
 
         // Corners
         if (self.borders.top and self.borders.left) {
@@ -275,4 +275,3 @@ pub const Table = @import("table.zig").Table;
 pub const TableBuilder = @import("table.zig").TableBuilder;
 pub const Row = @import("table.zig").Row;
 pub const Column = @import("table.zig").Column;
-


### PR DESCRIPTION
I added setting the terminal codepage to UTF8 to support unicode on Windows
Also I added a property `border_symbols` in Block, defaulting to `BorderSymbols.default()` now the symbols can be set from outside. Maybe the default could be `BorderSymbols.line()` and default could be renamed to `ascii`?

As a demo I changed some symbols in the dashboard example. I Tested it on Windows in the Windows Terminal and the legacy console host.

I hope you like it!

btw: I like your library, it's easy and small enough to understand but has enough features to be really useful!