### PR TITLE
Added github workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,29 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest stable Zig version
+        id: zig-version
+        run: |
+          VERSION=$(curl -s https://ziglang.org/download/index.json | jq -r 'keys[] | select(test("^[0-9]"))' | sort -V | tail -1) # Grabs latest stable release (master pulls from git repo)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Zig
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: ${{ steps.zig-version.outputs.version }}
+
+      - name: Build Examples
+        run: zig build examples
+
+      - name: Test
+        run: zig build test

--- a/.github/workflows/zig-compat.yml
+++ b/.github/workflows/zig-compat.yml
@@ -1,0 +1,56 @@
+name: Zig Compatibility Check
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  zig-compat:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch latest stable Zig version
+        id: fetch
+        run: |
+          VERSION=$(curl -s https://ziglang.org/download/index.json | jq -r 'keys[] | select(test("^[0-9]"))' | sort -V | tail -1) # Grab latest stable version
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Restore cached version
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .zig-version-cache
+          key: zig-version-${{ steps.fetch.outputs.version }}
+
+      - name: Check if already tested
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          echo "Already tested Zig ${{ steps.fetch.outputs.version }}, skipping"
+
+      - uses: actions/checkout@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Setup Zig
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: ${{ steps.fetch.outputs.version }}
+
+      - name: Build and Test
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          zig version
+          zig build examples
+          zig build test
+
+      - name: Create cache marker
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: echo "${{ steps.fetch.outputs.version }}" > .zig-version-cache
+
+      - name: Save cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .zig-version-cache
+          key: zig-version-${{ steps.fetch.outputs.version }}


### PR DESCRIPTION
Fix for [feature request](https://github.com/adxdits/zigtui/issues/16)

PR.yml tests for build status against pull requests zig-compat.yml runs every 24 hours and checks
for new zig version. if a new version is found
the workflow then tests if examples projects build if no new version is found it exits

master pulls from github repo and has further breaking changes that will need fixed. For now let's just pin to stable, we can look at the look-ahead workflow later (perhaps we can create a matrix that applies stable / master)

Note* You will need to enforce which workflows are required to pass for PR's in the repository configuration 
